### PR TITLE
Fix velocity message formatting

### DIFF
--- a/velocity/src/main/java/net/william278/huskchat/velocity/message/VelocityMessageManager.java
+++ b/velocity/src/main/java/net/william278/huskchat/velocity/message/VelocityMessageManager.java
@@ -93,14 +93,13 @@ public class VelocityMessageManager extends MessageManager {
 
     @Override
     public void sendFormattedChannelMessage(Player target, Player sender, Channel channel, String message) {
-        final TextComponent.Builder componentBuilder = Component.text()
-                .append(new MineDown(PlaceholderReplacer.replace(sender, channel.format, plugin))
-                        .toComponent());
+        final TextComponent.Builder componentBuilder = Component.text();
+
         if (sender.hasPermission("huskchat.formatted_chat")) {
-            componentBuilder.append(new MineDown(message).disable(MineDownParser.Option.ADVANCED_FORMATTING)
+            componentBuilder.append(new MineDown(PlaceholderReplacer.replace(sender, channel.format, plugin) + message)
                     .toComponent());
         } else {
-            componentBuilder.append(Component.text(message));
+            componentBuilder.append(new MineDown(PlaceholderReplacer.replace(sender, channel.format, plugin) + MineDown.escape(message)).toComponent());
         }
         VelocityPlayer.adaptVelocity(target).ifPresent(user -> user.sendMessage(componentBuilder.build()));
     }


### PR DESCRIPTION
Due to Minedown conversion, if there was %color% (or probably any other) tag on the end of configuration string in config.yml, the result converted message did not include the color tag, since any text was appended in separate conversion to Minedown, and their parser did not include "empty" string for color definition. This was solved by appending messages together before MineDown conversion. Unpermitted users have their messages escaped, before conversion, but this does not change any config.yml configuration.